### PR TITLE
Capping the number of active games in the maze

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,6 +29,8 @@ import Instructions from './components/world/Instructions';
 import {
   displayMazeGameInviteToast,
   displayMazeGameResponseToast,
+  displayMazeFullGameResponse,
+  displayInviteSent,
 } from './components/world/MazeGameToastUtils';
 import QuitGame from './components/world/QuitGame';
 import WorldMap from './components/world/WorldMap';
@@ -305,8 +307,11 @@ async function GameController(
     const recipient = Player.fromServerPlayer(recipientPlayer);
     const onGameResponse = (gameAcceptance: boolean) =>
       emitInviteResponse(sender, recipient, gameAcceptance);
-    displayMazeGameInviteToast(sender, onGameResponse);
-    dispatchAppUpdate({
+    if(gamePlayerID === senderPlayer._id) {
+      displayInviteSent(recipient);
+    } else {
+      displayMazeGameInviteToast(sender, onGameResponse);
+      dispatchAppUpdate({
       action: 'updateGameInfo',
       data: {
         gameStatus: 'invitePending',
@@ -314,7 +319,22 @@ async function GameController(
         recipientPlayer: recipient,
       },
     });
+  }
   });
+  socket.on(
+    'mazeFullGameResponse',
+    (senderPlayer: ServerPlayer) => {
+      const sender = Player.fromServerPlayer(senderPlayer);
+      displayMazeFullGameResponse();
+      dispatchAppUpdate({
+        action: 'updateGameInfo',
+        data: {
+          gameStatus: 'noGame',
+          senderPlayer: sender,
+        },
+      });
+    },
+  );
   socket.on(
     'mazeGameResponse',
     (senderPlayer: ServerPlayer, recipientPlayer: ServerPlayer, gameAcceptance: boolean) => {

--- a/frontend/src/components/VideoCall/VideoFrontend/components/ParticipantInfo/ParticipantInfo.tsx
+++ b/frontend/src/components/VideoCall/VideoFrontend/components/ParticipantInfo/ParticipantInfo.tsx
@@ -278,15 +278,6 @@ export default function ParticipantInfo({
                   const recipientPlayer = appState.players.find(player => player.id === profile.id);
                   if (senderPlayer && recipientPlayer) {
                     appState.emitGameInvite(senderPlayer, recipientPlayer);
-                    if (!toast.isActive(profile.id)) {
-                      toast({
-                        id: profile.id,
-                        title: `Invited ${recipientPlayer.userName} to race`,
-                        status: 'info',
-                        duration: 3000,
-                        isClosable: true,
-                      });
-                    }
                   }
                 }
               }}

--- a/frontend/src/components/world/MazeGameToastUtils.tsx
+++ b/frontend/src/components/world/MazeGameToastUtils.tsx
@@ -46,3 +46,25 @@ export function displayMazeGameResponseToast(recipientPlayer: Player, gameRespon
     isClosable: true,
   });
 }
+
+export function displayMazeFullGameResponse(): void {
+  const toastTitle = `Unable to send invite, the maze is full`;
+  const toast = createStandaloneToast();
+  toast({
+    title: toastTitle,
+    status: 'info',
+    duration: 3000,
+    isClosable: true,
+  });
+}
+
+export function displayInviteSent(recipientPlayer: Player): void {
+  const toastTitle = `Invited ${recipientPlayer.userName} to race`;
+  const toast = createStandaloneToast();
+  toast({
+    title: toastTitle,
+    status: 'info',
+    duration: 3000,
+    isClosable: true,
+  });
+}

--- a/services/roomService/src/lib/CoveyTownController.ts
+++ b/services/roomService/src/lib/CoveyTownController.ts
@@ -205,12 +205,16 @@ export default class CoveyTownController {
       return false;
     }
 
-    const listeners = this._listeners.filter(
-      listener => listener.listeningPlayerID === recipientPlayerID,
-    );
+    let listeners = this._listeners.filter(
+      listener => listener.listeningPlayerID === recipientPlayerID || 
+      listener.listeningPlayerID === senderPlayerID);
 
-    listeners.forEach(listener => listener.onMazeGameRequested(sender, recipient));
-
+    if (!Maze.getInstance().reachedCapacity()) {
+      listeners.forEach(listener => listener.onMazeGameRequested(sender, recipient));
+    } else {
+      listeners = listeners.filter(listener => listener.listeningPlayerID === senderPlayerID);
+      listeners.forEach(listener => listener.onFullMazeGameRequested(sender));
+    }
     return true;
   }
 }

--- a/services/roomService/src/lib/CoveyTownsStore.test.ts
+++ b/services/roomService/src/lib/CoveyTownsStore.test.ts
@@ -26,6 +26,9 @@ function mockCoveyListener(): CoveyTownListener {
     onMazeGameResponded(senderPlayer: Player, recipientPlayer: Player, gameAcceptance: boolean) {
       mockCoveyListenerOtherFns(senderPlayer, recipientPlayer, gameAcceptance);
     },
+    onFullMazeGameRequested(senderPlayer: Player) {
+      mockCoveyListenerOtherFns(senderPlayer);
+    },
   };
 }
 

--- a/services/roomService/src/requestHandlers/CoveyTownRequestHandlers.ts
+++ b/services/roomService/src/requestHandlers/CoveyTownRequestHandlers.ts
@@ -239,6 +239,9 @@ function townSocketAdapter(socket: Socket, listeningPlayerID?: string): CoveyTow
     onMazeGameResponded(senderPlayer: Player, recipientPlayer: Player, gameAcceptance: boolean) {
       socket.emit('mazeGameResponse', senderPlayer, recipientPlayer, gameAcceptance);
     },
+    onFullMazeGameRequested(senderPlayer: Player) {
+      socket.emit('mazeFullGameResponse', senderPlayer);
+    },
   };
 }
 

--- a/services/roomService/src/types/CoveyTownListener.ts
+++ b/services/roomService/src/types/CoveyTownListener.ts
@@ -45,4 +45,9 @@ export default interface CoveyTownListener {
    * @param senderPlayer the player that has done the inviting
    */
   onMazeGameResponded(senderPlayer: Player, recipientPlayer: Player, gameAcceptance: boolean): void;
+
+  /**
+   * Called when a player has requested to play a game but the Maze is full
+   */
+  onFullMazeGameRequested(senderPlayer: Player): void;
 }


### PR DESCRIPTION
Displays a toast and prevents a game from being created when a player tries to invite another player to a game when the maze is full. 
![cap maze](https://user-images.githubusercontent.com/33645566/114288386-6601ab00-9a3d-11eb-8f8f-d3c40f1f63b2.png)
