### PR TITLE
Leaderboard Modal

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,8 +75,7 @@ type CoveyAppUpdate =
   | { action: 'toggleQuit' }
   | { action: 'exitMaze' }
   | { action: 'closeInstructions' }
-  | { action: 'openLeaderboard' }
-  | { action: 'closeLeaderboard' }
+  | { action: 'toggleLeaderboard' }
   | {
       action: 'updateGameInfo';
       data: {
@@ -222,11 +221,8 @@ function appStateReducer(state: CoveyAppState, update: CoveyAppUpdate): CoveyApp
       closedInstructions = true;
       nextState.gameStarted = true;
       break;
-    case 'openLeaderboard':
-      nextState.showLeaderboard = true;
-      break;
-    case 'closeLeaderboard':
-      nextState.showLeaderboard = false;
+    case 'toggleLeaderboard':
+      nextState.showLeaderboard = !state.showLeaderboard;
       break;
     case 'disconnect':
       state.socket?.disconnect();
@@ -432,7 +428,7 @@ function App(props: { setOnDisconnect: Dispatch<SetStateAction<Callback | undefi
     return (
       <div>
         <WorldMap />
-        <Button onClick={() => dispatchAppUpdate({ action: 'openLeaderboard' })}>
+        <Button onClick={() => dispatchAppUpdate({ action: 'toggleLeaderboard' })}>
           Show Leaderboard
         </Button>
         <VideoOverlay preferredMode='fullwidth' />
@@ -447,7 +443,7 @@ function App(props: { setOnDisconnect: Dispatch<SetStateAction<Callback | undefi
         />
         <LeaderboardModal
           isOpen={appState.showLeaderboard}
-          onClose={() => dispatchAppUpdate({ action: 'closeLeaderboard' })}
+          onClose={() => dispatchAppUpdate({ action: 'toggleLeaderboard' })}
           leaderboardData={currentMazeCompletionList}
         />
       </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,10 +27,10 @@ import useConnectionOptions from './components/VideoCall/VideoFrontend/utils/use
 import VideoOverlay from './components/VideoCall/VideoOverlay/VideoOverlay';
 import Instructions from './components/world/Instructions';
 import {
+  displayInviteSent,
+  displayMazeFullGameResponse,
   displayMazeGameInviteToast,
   displayMazeGameResponseToast,
-  displayMazeFullGameResponse,
-  displayInviteSent,
 } from './components/world/MazeGameToastUtils';
 import QuitGame from './components/world/QuitGame';
 import WorldMap from './components/world/WorldMap';
@@ -306,34 +306,31 @@ async function GameController(
     const recipient = Player.fromServerPlayer(recipientPlayer);
     const onGameResponse = (gameAcceptance: boolean) =>
       emitInviteResponse(sender, recipient, gameAcceptance);
-    if(gamePlayerID === senderPlayer._id) {
+    if (gamePlayerID === senderPlayer._id) {
       displayInviteSent(recipient);
     } else {
       displayMazeGameInviteToast(sender, onGameResponse);
       dispatchAppUpdate({
-      action: 'updateGameInfo',
-      data: {
-        gameStatus: 'invitePending',
-        senderPlayer: sender,
-        recipientPlayer: recipient,
-      },
-    });
-  }
-  });
-  socket.on(
-    'mazeFullGameResponse',
-    (senderPlayer: ServerPlayer) => {
-      const sender = Player.fromServerPlayer(senderPlayer);
-      displayMazeFullGameResponse();
-      dispatchAppUpdate({
         action: 'updateGameInfo',
         data: {
-          gameStatus: 'noGame',
+          gameStatus: 'invitePending',
           senderPlayer: sender,
+          recipientPlayer: recipient,
         },
       });
-    },
-  );
+    }
+  });
+  socket.on('mazeFullGameResponse', (senderPlayer: ServerPlayer) => {
+    const sender = Player.fromServerPlayer(senderPlayer);
+    displayMazeFullGameResponse();
+    dispatchAppUpdate({
+      action: 'updateGameInfo',
+      data: {
+        gameStatus: 'noGame',
+        senderPlayer: sender,
+      },
+    });
+  });
   socket.on(
     'mazeGameResponse',
     (senderPlayer: ServerPlayer, recipientPlayer: ServerPlayer, gameAcceptance: boolean) => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -77,7 +77,6 @@ type CoveyAppUpdate =
   | { action: 'closeInstructions' }
   | { action: 'openLeaderboard' }
   | { action: 'closeLeaderboard' }
-  | { action: 'updateLeaderboard'; newEntries: MazeCompletionInfo[] }
   | {
       action: 'updateGameInfo';
       data: {

--- a/frontend/src/CoveyTypes.ts
+++ b/frontend/src/CoveyTypes.ts
@@ -45,5 +45,6 @@ export type CoveyAppState = {
   toggleQuit: boolean;
   quitGame: () => void;
   showInstructions: boolean;
+  showLeaderboard: boolean;
   gameStarted: boolean;
 };

--- a/frontend/src/classes/TownsServiceClient.ts
+++ b/frontend/src/classes/TownsServiceClient.ts
@@ -76,6 +76,19 @@ export interface TownUpdateRequest {
   isPubliclyListed?: boolean;
 }
 
+export interface MazeCompletionInfo {
+  playerID: string;
+  username: string;
+  time: number;
+}
+
+/**
+ * Response from the server for a Maze Completion Times request
+ */
+export interface MazeCompletionTimesResponse {
+  mazeCompletionTimes: MazeCompletionInfo[];
+}
+
 /**
  * Envelope that wraps any response from the server
  */
@@ -150,6 +163,13 @@ export default class TownsServiceClient {
 
   async joinTown(requestData: TownJoinRequest): Promise<TownJoinResponse> {
     const responseWrapper = await this._axios.post('/sessions', requestData);
+    return TownsServiceClient.unwrapOrThrowError(responseWrapper);
+  }
+
+  async getMazeCompletionTimes(): Promise<MazeCompletionTimesResponse> {
+    const responseWrapper = await this._axios.get<ResponseEnvelope<MazeCompletionTimesResponse>>(
+      '/maze-completion-times',
+    );
     return TownsServiceClient.unwrapOrThrowError(responseWrapper);
   }
 }

--- a/frontend/src/components/Login/TownSelectionPart1.test.tsx
+++ b/frontend/src/components/Login/TownSelectionPart1.test.tsx
@@ -109,6 +109,7 @@ function wrappedTownSelection() {
           toggleQuit: false,
           quitGame: () => {},
           showInstructions: false,
+          showLeaderboard: false,
           gameStarted: false,
         }}>
         <TownSelection doLogin={doLoginMock} />

--- a/frontend/src/components/Login/TownSelectionPart2.test.tsx
+++ b/frontend/src/components/Login/TownSelectionPart2.test.tsx
@@ -110,6 +110,7 @@ function wrappedTownSelection() {
           toggleQuit: false,
           quitGame: () => {},
           showInstructions: false,
+          showLeaderboard: false,
           gameStarted: false,
         }}>
         <TownSelection doLogin={doLoginMock} />

--- a/frontend/src/components/Login/TownSelectionPart3.test.tsx
+++ b/frontend/src/components/Login/TownSelectionPart3.test.tsx
@@ -110,6 +110,7 @@ function wrappedTownSelection() {
           toggleQuit: false,
           quitGame: () => {},
           showInstructions: false,
+          showLeaderboard: false,
           gameStarted: false,
         }}>
         <TownSelection doLogin={doLoginMock} />

--- a/frontend/src/components/Login/TownSettings.test.tsx
+++ b/frontend/src/components/Login/TownSettings.test.tsx
@@ -61,6 +61,7 @@ function wrappedTownSettings() {
           toggleQuit: false,
           quitGame: () => {},
           showInstructions: false,
+          showLeaderboard: false,
           gameStarted: false,
         }}>
         <TownSettings />

--- a/frontend/src/components/world/LeaderboardModal.tsx
+++ b/frontend/src/components/world/LeaderboardModal.tsx
@@ -1,0 +1,61 @@
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from '@chakra-ui/react';
+import React from 'react';
+import { MazeCompletionInfo } from '../../classes/TownsServiceClient';
+
+export default function LeaderboardModal(props: {
+  isOpen: boolean;
+  onClose: () => void;
+  leaderboardData: MazeCompletionInfo[];
+}): JSX.Element {
+  const { isOpen, onClose, leaderboardData } = props;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size='4xl'>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Corn Maze Leaderboard</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Table variant='simple' size='sm'>
+            <Thead>
+              <Tr>
+                <Th>Player ID</Th>
+                <Th>Username</Th>
+                <Th isNumeric>Completion Time (seconds)</Th>
+              </Tr>
+            </Thead>
+            <Tbody>
+              {leaderboardData.map(row => (
+                <Tr key={row.playerID}>
+                  <Td>{row.playerID}</Td>
+                  <Td>{row.username}</Td>
+                  <Td isNumeric>{row.time}</Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        </ModalBody>
+        <ModalFooter>
+          <Button colorScheme='blue' mr={3} onClick={onClose}>
+            Ok!
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}


### PR DESCRIPTION
- App State now contains `showLeaderboard` which can be used to trigger opening upon a sprite walking up to a point on the map (@lindojong)
- Formatting fixes are all in one commit so logic is contained fully here: https://github.com/jean-zhang/covey.town/commit/50bf718e65a469eb5fbfbd501223d49330e6ca0f 
- Leaderboard data is refetched every 3 seconds similarly to Town List

Screenshot:
<img width="1435" alt="Screen Shot 2021-04-12 at 2 25 52 AM" src="https://user-images.githubusercontent.com/33647880/114349842-67fb6500-9b36-11eb-8e6b-deda328c4dbe.png">
